### PR TITLE
Handle Chrome requirement that AudioContext be created in a user gesture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -2,3 +2,13 @@
 In-browser pitch detection and interval training tool.
 
 See the live demo here: https://isg.github.io/pitchpro/src/. (Chrome only, currently.)
+
+## Development
+
+To build the app, run...
+
+```
+npm install
+npm run build
+```
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,14 @@
+{
+  "name": "pitchpro",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "typescript": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "pitchpro",
+  "version": "1.0.0",
+  "description": "In-browser pitch detection and interval training tool.",
+  "main": "index.js",
+  "scripts": {
+    "build": "tsc src/js/main.ts",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/isg/pitchpro.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/isg/pitchpro/issues"
+  },
+  "homepage": "https://github.com/isg/pitchpro#readme",
+  "devDependencies": {
+    "typescript": "^3.8.3"
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -24,27 +24,34 @@
         <br/><br/>
         Pitch matching and interval training.
         <br/><br/>
-        Select an interval, and then hit <i>spacebar</i>. After the tone, try to sing the selected interval. Any octave is valid.
-        <br/><br/>
-        Interval:
-        <select id="interval-selection">
-            <option value="0">unison</option>
-            <option value="1">minor second</option>
-            <option value="2">major second</option>
-            <option value="3">minor third</option>
-            <option value="4">major third</option>
-            <option value="5">perfect fourth</option>
-            <option value="6">tritone</option>
-            <option value="7">perfect fifth</option>
-            <option value="8">minor sixth</option>
-            <option value="9">major sixth</option>
-            <option value="10">minor seventh</option>
-            <option value="11">major seventh</option>
-        </select>
-        <br/><br/>
-        <span id="feedback">
-            
-        </span>  
+
+        <div id="launch-button">
+            <button>
+                Get Started
+            </button>
+        </div>
+        <div id="interval-control" style="display: none;">
+            Select an interval, and then hit <i>spacebar</i>. After the tone, try to sing the selected interval. Any octave is valid.
+            <br/><br/>
+            Interval:
+            <select id="interval-selection">
+                <option value="0">unison</option>
+                <option value="1">minor second</option>
+                <option value="2">major second</option>
+                <option value="3">minor third</option>
+                <option value="4">major third</option>
+                <option value="5">perfect fourth</option>
+                <option value="6">tritone</option>
+                <option value="7">perfect fifth</option>
+                <option value="8">minor sixth</option>
+                <option value="9">major sixth</option>
+                <option value="10">minor seventh</option>
+                <option value="11">major seventh</option>
+            </select>
+            <br /><br />
+            <span id="feedback"></span>
+        </div>
+
     </div>   
 
     <input id="dial" type="text" class="dial" />

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -406,8 +406,14 @@ var PitchPro = /** @class */ (function () {
     return PitchPro;
 }());
 window.onload = function () {
-    var audio_manager = new AudioManager();
-    var recording_manager = new PianoRecordingManager();
+    var launchButton = document.getElementById('launch-button');
+    var intervalControl = document.getElementById('interval-control');
     var ui_manager = new KnobUIManager();
-    var pitch_pro = new PitchPro(ui_manager, recording_manager, audio_manager);
+    launchButton.addEventListener('click', function () {
+        launchButton.style.display = 'none';
+        intervalControl.style.display = null;
+        var audio_manager = new AudioManager();
+        var recording_manager = new PianoRecordingManager();
+        new PitchPro(ui_manager, recording_manager, audio_manager);
+    });
 };

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -25,7 +25,7 @@ function frequency_from_note(note) {
 function cents_off_from_pitch(frequency, note) {
     return Math.floor(1200 * Math.log(frequency / frequency_from_note(note)) / Math.log(2));
 }
-var AudioManager = (function () {
+var AudioManager = /** @class */ (function () {
     function AudioManager() {
         var _this = this;
         // Sets stuff up.
@@ -186,7 +186,7 @@ var AudioManager = (function () {
     AudioManager.FFT_SIZE = Math.pow(2, 14);
     return AudioManager;
 }());
-var KnobUIManager = (function () {
+var KnobUIManager = /** @class */ (function () {
     function KnobUIManager() {
         this.middle_text = $("#middle-text");
         $("#dial").knob({
@@ -233,7 +233,7 @@ var KnobUIManager = (function () {
     };
     return KnobUIManager;
 }());
-var PianoRecordingManager = (function () {
+var PianoRecordingManager = /** @class */ (function () {
     function PianoRecordingManager() {
         this.audio_by_midi_note = {
             48: new Audio('piano/3C.ogg'),
@@ -275,7 +275,7 @@ var PianoRecordingManager = (function () {
     };
     return PianoRecordingManager;
 }());
-var PitchPro = (function () {
+var PitchPro = /** @class */ (function () {
     function PitchPro(ui_manager, recording_manager, audio_manager) {
         var _this = this;
         this.listening = false;

--- a/src/js/main.ts
+++ b/src/js/main.ts
@@ -494,8 +494,16 @@ class PitchPro {
 
 }
 window.onload = function () {
-    let audio_manager = new AudioManager();
-    let recording_manager = new PianoRecordingManager();
+    const launchButton = document.getElementById('launch-button');
+    const intervalControl = document.getElementById('interval-control');
     let ui_manager = new KnobUIManager();
-    let pitch_pro = new PitchPro(ui_manager, recording_manager, audio_manager);
+
+    launchButton.addEventListener('click', () => {
+        launchButton.style.display = 'none';
+        intervalControl.style.display = null;
+
+        let audio_manager = new AudioManager();
+        let recording_manager = new PianoRecordingManager();
+        new PitchPro(ui_manager, recording_manager, audio_manager);
+    })
 }


### PR DESCRIPTION
I WANNA LEARN TO SING AND THIS SEEMS LIKE A GOOD APP FOR ME TO PRACTICE. THE PERSON WHO BUILT IT MUST BE A MOST GOOD AND EXCELLENT ENGINEER.

Chrome broke it though so it no longer works... Chrome requires `AudioContext` to be created inside a user gesture callback. WTF. I guess this is to prevent ads from doing sneaky stuff.

This PR fixes the issue by requiring users to click a "Get Started" button to start the app...

![Screen Shot 2020-05-06 at 7 13 03 PM](https://user-images.githubusercontent.com/945937/81247090-fafa5980-8fcd-11ea-9f8a-0601663a84dc.png)

Doing so creates the Audio context and prompts you for audio permission...

![Screen Shot 2020-05-06 at 7 13 07 PM](https://user-images.githubusercontent.com/945937/81247104-051c5800-8fce-11ea-8be0-1e8b31cfd9dc.png)

After which it works again!

![Screen Shot 2020-05-06 at 7 13 12 PM](https://user-images.githubusercontent.com/945937/81247128-106f8380-8fce-11ea-8cfe-68d17952defa.png)

I also added a package.json and some instructions for building the app :)